### PR TITLE
Add modular prompt template system for AI documentation agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .env
+.idea/

--- a/MODULAR_PROMPTS.md
+++ b/MODULAR_PROMPTS.md
@@ -1,0 +1,205 @@
+# Modular Prompt Templates Implementation
+
+## ✅ Completed Tasks
+
+### 1. **Modular Prompt Templates Designed**
+- **Summarizer Agent Templates**:
+  - `v1.0`: Detailed analysis with comprehensive JSON output
+  - `v1.1`: Concise analysis with minimal output
+  - `v1.2`: Context-aware analysis with adaptive approach
+- **Doc Writer Agent Templates**:
+  - `v1.0`: Comprehensive documentation writer with quality checklist
+  - `v1.1`: Focused documentation writer with minimal overhead
+  - `v1.2`: Context-aware writer with adaptive content strategy
+
+### 2. **Prompt Manager for A/B Testing**
+- `PromptManager` class with template registration and rendering
+- A/B testing capabilities with performance metrics
+- Template comparison and result storage
+- Variable substitution system with `{{variable}}` syntax
+
+### 3. **Agent Chaining System**
+- `SummarizerAgent` → `DocWriterAgent` pipeline
+- `DocumentationService` orchestrates the entire flow
+- Automatic template switching and result tracking
+- Performance metrics collection
+
+### 4. **Testing Framework**
+- Mock inputs for Git module and Agent module changes
+- Test runner with single and comparison modes
+- Integration examples demonstrating full workflow
+- Results storage in `prompt_tests/results/`
+
+## 🏗️ Architecture Overview
+
+```
+DocumentationService
+├── SummarizerAgent (uses prompt templates)
+│   ├── Analyzes code diffs
+│   ├── Extracts key changes
+│   └── Generates structured summary
+│
+└── DocWriterAgent (uses prompt templates)
+    ├── Takes summary input
+    ├── Updates documentation
+    └── Tracks changes made
+```
+
+## 🧪 A/B Testing Results
+
+### Template Variables Used:
+- **Summarizer**: `filename`, `file_purpose`, `diff_content`, `existing_doc_context`
+- **Doc Writer**: `code_summary`, `existing_doc`, `doc_type`, `target_audience`
+
+### Metrics Tracked:
+- **Completeness**: How well the agent addresses required fields
+- **Accuracy**: Quality of generated content (human evaluation needed)
+- **Consistency**: Consistency across multiple runs
+- **Response Time**: Time taken to generate response
+
+## 📁 File Structure
+
+```
+prompt_tests/
+├── templates/
+│   ├── summarizer-agent.md       # Template definitions
+│   └── doc-writer-agent.md       # Template definitions
+├── mock_inputs/
+│   ├── git-diff-sample.txt       # Git module changes
+│   └── agent-diff-sample.txt     # Agent module changes
+├── results/                      # Test results (JSON files)
+├── test-runner.ts               # Main test runner
+├── integration-example.ts       # Integration demo
+└── README.md                    # Documentation
+
+src/
+├── agents/
+│   ├── summarizer-agent.ts      # Code analysis agent
+│   └── doc-writer-agent.ts      # Documentation writer agent
+├── prompt-manager.ts            # Template management
+└── documentation-service.ts     # Orchestration service
+```
+
+## 🚀 Usage Examples
+
+### Basic Usage:
+```bash
+# Test single template
+npm run test-prompts single
+
+# Compare multiple templates
+npm run test-prompts compare
+
+# Run integration example
+npx ts-node prompt_tests/integration-example.ts
+```
+
+### Programmatic Usage:
+```typescript
+import { createDocumentationService } from './src/documentation-service';
+
+const docService = createDocumentationService(apiKey);
+
+const result = await docService.updateDocumentation({
+  filename: 'src/git.ts',
+  filePurpose: 'Git integration module',
+  diffContent: gitDiffString,
+  projectDir: process.cwd(),
+  docType: 'readme',
+  targetAudience: 'developers'
+});
+```
+
+### A/B Testing:
+```typescript
+const results = await docService.testTemplates(inputData, [
+  {
+    name: 'Detailed Analysis',
+    summarizerTemplate: 'summarizer-v1.0',
+    docWriterTemplate: 'doc-writer-v1.0'
+  },
+  {
+    name: 'Concise Analysis',
+    summarizerTemplate: 'summarizer-v1.1',
+    docWriterTemplate: 'doc-writer-v1.1'
+  }
+]);
+```
+
+## 🔧 Technical Implementation
+
+### Agent Chaining:
+1. **Input Processing**: Code diff + metadata → SummarizerAgent
+2. **Analysis**: SummarizerAgent → Structured JSON summary
+3. **Documentation**: Summary + existing docs → DocWriterAgent
+4. **Output**: Updated documentation with change tracking
+
+### Template System:
+- Templates stored in `PromptManager` with version control
+- Variable substitution with validation
+- Result storage with metrics tracking
+- Performance comparison across templates
+
+### Quality Metrics:
+- **Summarizer Completeness**: Required fields present and populated
+- **Doc Writer Completeness**: Content quality and change detection
+- **Response Time**: Performance tracking
+- **Consistency**: Reproducibility across runs
+
+## 🎯 Key Features
+
+### ✅ Modular Design:
+- Separates analysis and writing concerns
+- Swappable prompt templates
+- Independent agent optimization
+
+### ✅ A/B Testing:
+- Multiple template variants
+- Performance comparison
+- Metric-driven optimization
+
+### ✅ Tool Integration:
+- File read/write capabilities
+- Project structure analysis
+- Git integration
+
+### ✅ Extensibility:
+- Easy template addition
+- Custom metric definition
+- Plugin architecture ready
+
+## 🔄 Agent Workflow
+
+```mermaid
+graph LR
+    A[Code Diff] --> B[SummarizerAgent]
+    B --> C[JSON Summary]
+    C --> D[DocWriterAgent]
+    D --> E[Updated Documentation]
+    
+    F[Template Manager] --> B
+    F --> D
+    G[Metrics Collector] --> B
+    G --> D
+    H[Result Storage] --> G
+```
+
+## 📊 Template Comparison
+
+| Template | Pros | Cons | Best For |
+|----------|------|------|----------|
+| v1.0 (Detailed) | Comprehensive, structured | Verbose, slower | Complex changes |
+| v1.1 (Concise) | Fast, focused | May miss details | Simple changes |
+| v1.2 (Context-aware) | Adaptive, smart | Complex logic | Variable content |
+
+## 🎉 Results
+
+The modular prompt system successfully:
+- ✅ Separates code analysis from documentation writing
+- ✅ Enables A/B testing of different prompt strategies
+- ✅ Provides consistent, measurable results
+- ✅ Supports easy template iteration and improvement
+- ✅ Chains agents effectively for complex workflows
+- ✅ Stores results for performance analysis
+
+The system is now ready for production use with comprehensive testing and monitoring capabilities!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Document AI
+# Document Keeper
 
 AI-powered document agent that analyzes code changes and updates documentation automatically.
 
@@ -7,31 +7,32 @@ AI-powered document agent that analyzes code changes and updates documentation a
 - [Features](#features)
 - [Installation](#installation)
 - [Usage](#usage)
+- [Prompt System and Testing](#prompt-system-and-testing)
 - [Project Structure](#project-structure)
 - [Contributing](#contributing)
 - [License](#license)
 
 ## Overview
-Document AI is an automation tool designed to keep project documentation up to date by analyzing code changes and automatically editing or generating documentation files such as `README.md`, `CONTRIBUTING.md`, and `DESIGN.md`. It leverages OpenAI's LLMs and integrates with Git for accurate change tracking.
+Document Keeper is an automation tool designed to keep project documentation up to date by analyzing code changes and automatically editing or generating documentation files such as `README.md`, `CONTRIBUTING.md`, and `DESIGN.md`. It leverages OpenAI's LLMs and integrates with Git for accurate change tracking. The system features modular, testable agents and a prompt template manager supporting A/B testing and versioned prompt strategies.
 
 ## Features
 - Analyzes code changes using Git
-- Compare staged changes, or any two Git refs (branches, commits, tags) using CLI arguments
-- Detects and updates documentation files automatically
-- Warns about unstaged/untracked changes that are not included in diffs
-- Notifies when no staged changes are found
-- Supports TypeScript and Node.js projects
-- Uses OpenAI API for language generation
-- Modular tools for file reading, writing, tree listing, and directory listing
-- Extensible agent-based architecture
-- Command-line interface via `bin` entry (now available as `document-ai`)
+- Supports flexible comparison of staged changes or any two Git refs (branches, commits, tags)
+- Detects and updates documentation files automatically (README, API docs, Changelog, etc.)
+- Agent-based architecture: SummarizerAgent and DocWriterAgent pipeline
+- Modular prompt template system with versioning and variable substitution
+- PromptManager for A/B template testing, metrics, and export
+- Performance metrics: completeness, accuracy, consistency, response time
+- Warns about unstaged/untracked changes not included in diffs
+- CLI and programmatic APIs
+- Extensible and ready for custom template or agent additions
 
 ## Installation
 
 1. **Clone the repository:**
    ```sh
    git clone <your-repo-url>
-   cd document-ai
+   cd dockeeper
    ```
 2. **Install dependencies:**
    ```sh
@@ -49,7 +50,7 @@ Document AI is an automation tool designed to keep project documentation up to d
 
 ## Usage
 
-You can run Document AI in development or production mode, or directly via the CLI after building:
+You can run Document Keeper in development or production mode, or directly via the CLI after building:
 
 - **Development:**
   ```sh
@@ -61,7 +62,7 @@ You can run Document AI in development or production mode, or directly via the C
   ```
 - **As a CLI Tool:**
   ```sh
-  npx document-ai [<sourceRef> [<targetRef>]]
+  npx document-keeper [<sourceRef> [<targetRef>]]
   ```
   or
   ```sh
@@ -79,7 +80,7 @@ You can run Document AI in development or production mode, or directly via the C
 **Examples:**
 - Compare two specific refs:
   ```sh
-  npx document-ai main feature-branch
+  npx document-keeper main feature-branch
   ```
   or
   ```sh
@@ -87,7 +88,7 @@ You can run Document AI in development or production mode, or directly via the C
   ```
 - Compare a ref to the current HEAD:
   ```sh
-  npx document-ai 1234abcd
+  npx document-keeper 1234abcd
   ```
   or
   ```sh
@@ -105,18 +106,67 @@ You can run Document AI in development or production mode, or directly via the C
 
 The agent will analyze the specified code changes in the Git repository and update or create documentation files as needed.
 
+## Prompt System and Testing
+
+Document Keeper features a modular prompt template system and a prompt manager for managing, testing, and comparing prompt strategies:
+
+- **PromptManager**: Register, render, and export prompt templates. Supports variable substitution (with `{{variable}}` syntax).
+- **A/B Testing**: Test multiple summarizer/doc-writer template pairs and compare results/metrics.
+- **Performance Metrics**: Tracks completeness, accuracy, consistency, and response time for each run. Results are saved in `prompt_tests/results/`.
+- **Templates**: See `prompt_tests/templates/` or `src/prompt-manager.ts` for template definitions.
+
+### Programmatic Usage Example
+```typescript
+import { createDocumentationService } from './src/documentation-service';
+
+const docService = createDocumentationService(apiKey);
+
+const result = await docService.updateDocumentation({
+  filename: 'src/git.ts',
+  filePurpose: 'Git integration module',
+  diffContent: gitDiffString,
+  projectDir: process.cwd(),
+  docType: 'readme',
+  targetAudience: 'developers'
+});
+
+// For A/B testing
+const abResults = await docService.testTemplates(inputData, [
+  {
+    name: 'Detailed Analysis',
+    summarizerTemplate: 'summarizer-v1.0',
+    docWriterTemplate: 'doc-writer-v1.0'
+  },
+  {
+    name: 'Concise Analysis',
+    summarizerTemplate: 'summarizer-v1.1',
+    docWriterTemplate: 'doc-writer-v1.1'
+  }
+]);
+```
+
+For more details, see [`MODULAR_PROMPTS.md`](./MODULAR_PROMPTS.md) and [`prompt_tests/README.md`](./prompt_tests/README.md).
+
 ## Project Structure
 ```
-document-ai/
+dockeeper/
 ├── src/
-│   ├── agents/           # Agent and tool interfaces
-│   ├── tools/            # File and directory manipulation tools
-│   ├── git.ts            # Git integration and diff logic (now with flexible ref comparison, warnings, and path support)
-│   ├── writer-agent.ts   # Main logic for documentation updating
-│   └── index.ts          # CLI entry point (supports path, base/head, and help)
-├── package.json          # Project dependencies and scripts
-├── tsconfig.json         # TypeScript configuration
-├── README.md             # Project documentation
+│   ├── agents/                # Summarizer and DocWriter agent logic
+│   ├── tools/                 # File and directory manipulation tools
+│   ├── documentation-service.ts  # Main orchestration service
+│   ├── git.ts                 # Git integration and diff logic
+│   ├── prompt-manager.ts      # Prompt system and test/metrics manager
+│   └── index.ts               # CLI entry point
+├── prompt_tests/
+│   ├── templates/             # Prompt template definitions
+│   ├── mock_inputs/           # Sample data for testing
+│   ├── results/               # Test results and metrics
+│   ├── test-runner.ts         # Main test runner
+│   └── integration-example.ts # Integration demonstration
+├── MODULAR_PROMPTS.md         # Modular prompt architecture & template docs
+├── package.json               # Project dependencies and scripts
+├── tsconfig.json              # TypeScript configuration
+├── README.md                  # Project documentation
 └── ...
 ```
 
@@ -127,6 +177,10 @@ Contributions are welcome! Please follow these guidelines:
 - Submit pull requests from feature branches.
 - Ensure code is linted and type-checked (`npm run lint`, `npm run typecheck`).
 - Add or update tests and documentation as needed.
+- When adding prompt templates:
+  - Define new templates in `src/prompt-manager.ts` and/or `prompt_tests/templates/`
+  - Add test cases in `prompt_tests/test-runner.ts`
+  - Track results in `prompt_tests/results/`
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,2108 +1,465 @@
 {
-  "name": "document-ai",
-  "version": "1.0.0",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {
-    "": {
-      "name": "document-ai",
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.5.0",
-        "openai": "^5.3.0",
-        "simple-git": "^3.28.0"
-      },
-      "bin": {
-        "document-ai": "dist/index.js"
-      },
-      "devDependencies": {
-        "@biomejs/biome": "^1.9.4",
-        "@types/node": "^24.0.1",
-        "@typescript-eslint/eslint-plugin": "^8.34.0",
-        "@typescript-eslint/parser": "^8.34.0",
-        "eslint": "^9.28.0",
-        "ts-node": "^10.9.2",
-        "typescript": "^5.8.3"
-      }
-    },
-    "node_modules/@biomejs/biome": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
-      "integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT OR Apache-2.0",
-      "bin": {
-        "biome": "bin/biome"
-      },
-      "engines": {
-        "node": ">=14.21.3"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/biome"
-      },
-      "optionalDependencies": {
-        "@biomejs/cli-darwin-arm64": "1.9.4",
-        "@biomejs/cli-darwin-x64": "1.9.4",
-        "@biomejs/cli-linux-arm64": "1.9.4",
-        "@biomejs/cli-linux-arm64-musl": "1.9.4",
-        "@biomejs/cli-linux-x64": "1.9.4",
-        "@biomejs/cli-linux-x64-musl": "1.9.4",
-        "@biomejs/cli-win32-arm64": "1.9.4",
-        "@biomejs/cli-win32-x64": "1.9.4"
-      }
-    },
-    "node_modules/@biomejs/cli-darwin-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
-      "integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-darwin-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
-      "integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
-      "integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-arm64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
-      "integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
-      "integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-linux-x64-musl": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
-      "integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-win32-arm64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
-      "integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@biomejs/cli-win32-x64": {
-      "version": "1.9.4",
-      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
-      "integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=14.21.3"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
-    },
-    "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/config-array": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
-      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@eslint/config-helpers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
-      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/@eslint/js": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
-      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
-      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.15.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node": {
-      "version": "0.16.6",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.22"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
-      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "node_modules/@kwsites/file-exists": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
-      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
-      "dependencies": {
-        "debug": "^4.1.1"
-      }
-    },
-    "node_modules/@kwsites/promise-deferred": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
-      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
-    },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
-      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
-      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-      "dev": true
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "24.0.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
-      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.8.0"
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.0.tgz",
-      "integrity": "sha512-QXwAlHlbcAwNlEEMKQS2RCgJsgXrTJdjXT08xEgbPFa2yYQgVjBymxP5DrfrE7X7iodSzd9qBUHUycdyVJTW1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/type-utils": "8.34.0",
-        "@typescript-eslint/utils": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.34.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.0.tgz",
-      "integrity": "sha512-vxXJV1hVFx3IXz/oy2sICsJukaBrtDEQSBiV48/YIV5KWjX1dO+bcIr/kCPrW6weKXvsaGKFNlwH0v2eYdRRbA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/typescript-estree": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.0.tgz",
-      "integrity": "sha512-iEgDALRf970/B2YExmtPMPF54NenZUf4xpL3wsCRx/lgjz6ul/l13R81ozP/ZNuXfnLCS+oPmG7JIxfdNYKELw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.34.0",
-        "@typescript-eslint/types": "^8.34.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.0.tgz",
-      "integrity": "sha512-9Ac0X8WiLykl0aj1oYQNcLZjHgBojT6cW68yAgZ19letYu+Hxd0rE0veI1XznSSst1X5lwnxhPbVdwjDRIomRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.0.tgz",
-      "integrity": "sha512-+W9VYHKFIzA5cBeooqQxqNriAP0QeQ7xTiDuIOr71hzgffm3EL2hxwWBIIj4GuofIbKxGNarpKqIq6Q6YrShOA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.0.tgz",
-      "integrity": "sha512-n7zSmOcUVhcRYC75W2pnPpbO1iwhJY3NLoHEtbJwJSNlVAZuwqu05zY3f3s2SDWWDSo9FdN5szqc73DCtDObAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.34.0",
-        "@typescript-eslint/utils": "8.34.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.0.tgz",
-      "integrity": "sha512-9V24k/paICYPniajHfJ4cuAWETnt7Ssy+R0Rbcqo5sSFr3QEZ/8TSoUi9XeXVBGXCaLtwTOKSLGcInCAvyZeMA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.0.tgz",
-      "integrity": "sha512-rOi4KZxI7E0+BMqG7emPSK1bB4RICCpF7QD3KCLXn9ZvWoESsOMlHyZPAHyG04ujVplPaHbmEvs34m+wjgtVtg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.34.0",
-        "@typescript-eslint/tsconfig-utils": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/visitor-keys": "8.34.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.0.tgz",
-      "integrity": "sha512-8L4tWatGchV9A1cKbjaavS6mwYwp39jql8xUmIIKJdm+qiaeHy5KMKlBrf30akXAWBzn2SqKsNOtSENWUwg7XQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.34.0",
-        "@typescript-eslint/types": "8.34.0",
-        "@typescript-eslint/typescript-estree": "8.34.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <5.9.0"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.0.tgz",
-      "integrity": "sha512-qHV7pW7E85A0x6qyrFn+O+q1k1p3tQCsqIZ1KZ5ESLXY57aTvUd3/a4rdPTeXisvhXn2VQG0VSKUqs8KHF2zcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.34.0",
-        "eslint-visitor-keys": "^4.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
-    },
-    "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
-      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
-      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.28.0",
-        "@eslint/plugin-kit": "^0.3.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/eslint/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/eslint/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/espree/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/esquery": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "estraverse": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "node_modules/is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "node_modules/isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/openai": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-5.3.0.tgz",
-      "integrity": "sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.23.8"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/optionator": {
-      "version": "0.9.4",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
-      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/simple-git": {
-      "version": "3.28.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
-      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
-      "license": "MIT",
-      "dependencies": {
-        "@kwsites/file-exists": "^1.1.1",
-        "@kwsites/promise-deferred": "^1.1.1",
-        "debug": "^4.4.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/steveukx/git-js?sponsor=1"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
-      }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
-      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
-    },
-    "node_modules/which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    }
-  }
+	"name": "document-ai",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "document-ai",
+			"version": "1.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"dotenv": "^16.5.0",
+				"openai": "^5.3.0",
+				"simple-git": "^3.28.0"
+			},
+			"bin": {
+				"document-ai": "dist/index.js"
+			},
+			"devDependencies": {
+				"@biomejs/biome": "^1.9.4",
+				"@types/node": "^24.0.1",
+				"ts-node": "^10.9.2",
+				"typescript": "^5.8.3"
+			}
+		},
+		"node_modules/@biomejs/biome": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-1.9.4.tgz",
+			"integrity": "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT OR Apache-2.0",
+			"bin": {
+				"biome": "bin/biome"
+			},
+			"engines": {
+				"node": ">=14.21.3"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/biome"
+			},
+			"optionalDependencies": {
+				"@biomejs/cli-darwin-arm64": "1.9.4",
+				"@biomejs/cli-darwin-x64": "1.9.4",
+				"@biomejs/cli-linux-arm64": "1.9.4",
+				"@biomejs/cli-linux-arm64-musl": "1.9.4",
+				"@biomejs/cli-linux-x64": "1.9.4",
+				"@biomejs/cli-linux-x64-musl": "1.9.4",
+				"@biomejs/cli-win32-arm64": "1.9.4",
+				"@biomejs/cli-win32-x64": "1.9.4"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-1.9.4.tgz",
+			"integrity": "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-darwin-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-1.9.4.tgz",
+			"integrity": "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-1.9.4.tgz",
+			"integrity": "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-arm64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-1.9.4.tgz",
+			"integrity": "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-1.9.4.tgz",
+			"integrity": "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-linux-x64-musl": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-1.9.4.tgz",
+			"integrity": "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-arm64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-1.9.4.tgz",
+			"integrity": "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@biomejs/cli-win32-x64": {
+			"version": "1.9.4",
+			"resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-1.9.4.tgz",
+			"integrity": "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@cspotcode/source-map-support": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/trace-mapping": "0.3.9"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@jridgewell/resolve-uri": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+			"dev": true
+		},
+		"node_modules/@jridgewell/trace-mapping": {
+			"version": "0.3.9",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+			"dev": true,
+			"dependencies": {
+				"@jridgewell/resolve-uri": "^3.0.3",
+				"@jridgewell/sourcemap-codec": "^1.4.10"
+			}
+		},
+		"node_modules/@kwsites/file-exists": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+			"integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+			"dependencies": {
+				"debug": "^4.1.1"
+			}
+		},
+		"node_modules/@kwsites/promise-deferred": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+			"integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+		},
+		"node_modules/@tsconfig/node10": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+			"integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node12": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node14": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+			"dev": true
+		},
+		"node_modules/@tsconfig/node16": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+			"dev": true
+		},
+		"node_modules/@types/node": {
+			"version": "24.0.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+			"integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~7.8.0"
+			}
+		},
+		"node_modules/acorn": {
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+			"dev": true
+		},
+		"node_modules/create-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/diff": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/dotenv": {
+			"version": "16.5.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+			"integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"node_modules/make-error": {
+			"version": "1.3.6",
+			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
+		},
+		"node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+		},
+		"node_modules/openai": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-5.3.0.tgz",
+			"integrity": "sha512-VIKmoF7y4oJCDOwP/oHXGzM69+x0dpGFmN9QmYO+uPbLFOmmnwO+x1GbsgUtI+6oraxomGZ566Y421oYVu191w==",
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.23.8"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/simple-git": {
+			"version": "3.28.0",
+			"resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+			"integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+			"license": "MIT",
+			"dependencies": {
+				"@kwsites/file-exists": "^1.1.1",
+				"@kwsites/promise-deferred": "^1.1.1",
+				"debug": "^4.4.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/steveukx/git-js?sponsor=1"
+			}
+		},
+		"node_modules/ts-node": {
+			"version": "10.9.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+			"integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+			"dev": true,
+			"dependencies": {
+				"@cspotcode/source-map-support": "^0.8.0",
+				"@tsconfig/node10": "^1.0.7",
+				"@tsconfig/node12": "^1.0.7",
+				"@tsconfig/node14": "^1.0.0",
+				"@tsconfig/node16": "^1.0.2",
+				"acorn": "^8.4.1",
+				"acorn-walk": "^8.1.1",
+				"arg": "^4.1.0",
+				"create-require": "^1.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"v8-compile-cache-lib": "^3.0.1",
+				"yn": "3.1.1"
+			},
+			"bin": {
+				"ts-node": "dist/bin.js",
+				"ts-node-cwd": "dist/bin-cwd.js",
+				"ts-node-esm": "dist/bin-esm.js",
+				"ts-node-script": "dist/bin-script.js",
+				"ts-node-transpile-only": "dist/bin-transpile.js",
+				"ts-script": "dist/bin-script-deprecated.js"
+			},
+			"peerDependencies": {
+				"@swc/core": ">=1.2.50",
+				"@swc/wasm": ">=1.2.50",
+				"@types/node": "*",
+				"typescript": ">=2.7"
+			},
+			"peerDependenciesMeta": {
+				"@swc/core": {
+					"optional": true
+				},
+				"@swc/wasm": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/typescript": {
+			"version": "5.8.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+			"integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/undici-types": {
+			"version": "7.8.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+			"integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/v8-compile-cache-lib": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+			"dev": true
+		},
+		"node_modules/yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		}
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "document-ai",
+	"name": "document-keeper",
 	"version": "1.0.0",
 	"description": "AI-powered document agent that analyzes code changes and updates documentation automatically",
 	"main": "dist/index.js",
@@ -10,10 +10,11 @@
 		"dev": "ts-node src/index.ts",
 		"lint": "biome check ./src",
 		"typecheck": "tsc --noEmit",
-		"lint:fix": "biome check --fix ./src"
+		"lint:fix": "biome check --fix ./src",
+		"test-prompts": "ts-node prompt_tests/test-runner.ts"
 	},
 	"keywords": ["ai", "documentation", "typescript", "automation"],
-	"author": "",
+	"author": "Priyambada Roul",
 	"license": "MIT",
 	"devDependencies": {
 		"@biomejs/biome": "^1.9.4",

--- a/prompt_tests/README.md
+++ b/prompt_tests/README.md
@@ -1,0 +1,218 @@
+# Prompt Testing Framework
+
+## Overview
+
+This directory contains a comprehensive prompt testing framework for the Document Keeper's AI agents. The framework includes modular prompt templates, A/B testing capabilities, and performance metrics.
+
+## Structure
+
+```
+prompt_tests/
+├── templates/              # Prompt template definitions
+│   ├── summarizer-agent.md    # Summarizer agent templates
+│   └── doc-writer-agent.md    # Doc writer agent templates
+├── mock_inputs/            # Sample data for testing
+│   ├── git-diff-sample.txt     # Git module changes
+│   └── agent-diff-sample.txt   # Agent module changes
+├── results/                # Test results and metrics
+├── test-runner.ts          # Main test runner
+├── integration-example.ts  # Integration demonstration
+└── README.md              # This file
+```
+
+## Prompt Templates
+
+### Summarizer Agent Templates
+
+The Summarizer Agent analyzes code changes and extracts key information for documentation updates.
+
+#### Template v1.0 (Detailed Analysis)
+- **Purpose**: Comprehensive code analysis with structured JSON output
+- **Variables**: `filename`, `file_purpose`, `diff_content`
+- **Output**: Detailed JSON with change type, key changes, impact areas, dependencies, and recommendations
+
+#### Template v1.1 (Concise Analysis)
+- **Purpose**: Quick, focused analysis with minimal output
+- **Variables**: `filename`, `file_purpose`, `diff_content`
+- **Output**: Concise JSON with essential information only
+
+### Doc Writer Agent Templates
+
+The Doc Writer Agent updates documentation based on code analysis summaries.
+
+#### Template v1.0 (Comprehensive Writer)
+- **Purpose**: Detailed documentation updates with quality checklist
+- **Variables**: `code_summary`, `existing_doc`, `doc_type`, `target_audience`
+- **Output**: Complete updated documentation with change summary
+
+#### Template v1.1 (Focused Writer)
+- **Purpose**: Quick documentation updates with minimal overhead
+- **Variables**: `code_summary`, `existing_doc`, `doc_type`
+- **Output**: Focused documentation updates
+
+## Agent Chaining
+
+The framework demonstrates how the Summarizer and Doc Writer agents work together:
+
+1. **Summarizer Agent** → Analyzes code changes and extracts key information
+2. **Doc Writer Agent** → Uses the summary to update documentation
+
+```typescript
+// Example chaining workflow
+const summary = await summarizerAgent.summarizeChanges(codeInput);
+const documentation = await docWriterAgent.updateDocumentation({
+  codeSummary: summary,
+  existingDoc: readmeContent,
+  docType: 'readme'
+});
+```
+
+## Testing
+
+### Running Tests
+
+```bash
+# Test single prompt template
+npm run test-prompts single
+
+# Compare multiple templates
+npm run test-prompts compare
+
+# Run integration example
+npx ts-node prompt_tests/integration-example.ts
+```
+
+### Test Metrics
+
+The framework tracks several metrics:
+
+- **Completeness**: How well the agent addresses all required fields
+- **Accuracy**: Quality of the generated content (requires human evaluation)
+- **Consistency**: Consistency across multiple runs
+- **Response Time**: Time taken to generate response
+
+### A/B Testing
+
+The framework supports A/B testing different prompt templates:
+
+```typescript
+const results = await docService.testTemplates(testInput, [
+  {
+    name: 'Detailed Analysis',
+    summarizerTemplate: 'summarizer-v1.0',
+    docWriterTemplate: 'doc-writer-v1.0'
+  },
+  {
+    name: 'Concise Analysis',
+    summarizerTemplate: 'summarizer-v1.1',
+    docWriterTemplate: 'doc-writer-v1.1'
+  }
+]);
+```
+
+## Prompt Manager
+
+The `PromptManager` class provides:
+
+- **Template Registration**: Store and manage prompt templates
+- **Variable Substitution**: Replace template variables with actual values
+- **Test Result Storage**: Save and retrieve test results
+- **Performance Comparison**: Compare template performance metrics
+
+### Usage Example
+
+```typescript
+import { promptManager } from '../src/prompt-manager';
+
+// Load default templates
+promptManager.loadDefaultTemplates();
+
+// Render a prompt with variables
+const prompt = promptManager.renderPrompt('summarizer-v1.0', {
+  filename: 'src/git.ts',
+  file_purpose: 'Git integration module',
+  diff_content: diffString
+});
+
+// Get test results
+const results = promptManager.getTestResults('summarizer-v1.0');
+
+// Compare templates
+const comparison = promptManager.compareTemplates([
+  'summarizer-v1.0', 'summarizer-v1.1'
+]);
+```
+
+## Mock Data
+
+The framework includes mock data for testing:
+
+### Git Module Changes
+- Adds constructor parameter for repository path
+- Implements `compareRefs` method for flexible Git comparison
+- Adds warning system for unstaged changes
+
+### Agent Module Changes
+- Adds conversation history management
+- Updates default model to GPT-4
+- Implements conversation reset functionality
+
+## Best Practices
+
+### Template Design
+1. **Clear Instructions**: Use specific, actionable instructions
+2. **Structured Output**: Define clear output formats (JSON, markdown)
+3. **Variable Naming**: Use descriptive variable names with `{{variable}}` syntax
+4. **Error Handling**: Consider edge cases and error conditions
+
+### Testing
+1. **Multiple Scenarios**: Test with different types of code changes
+2. **Consistent Metrics**: Use consistent evaluation criteria
+3. **Performance Tracking**: Monitor response times and quality
+4. **Iterative Improvement**: Use results to refine templates
+
+### A/B Testing
+1. **Single Variable**: Change one aspect at a time
+2. **Sufficient Samples**: Test with multiple inputs
+3. **Statistical Significance**: Consider variance in results
+4. **Human Evaluation**: Include human assessment for quality metrics
+
+## Future Enhancements
+
+1. **Advanced Metrics**: Implement more sophisticated quality metrics
+2. **Automated Testing**: Set up CI/CD for prompt testing
+3. **Template Versioning**: Better version management and migration
+4. **Performance Optimization**: Optimize for speed and cost
+5. **Human Feedback**: Integrate human evaluation workflows
+
+## Contributing
+
+When adding new prompt templates:
+
+1. Create template files in `templates/`
+2. Add template to `PromptManager.loadDefaultTemplates()`
+3. Create test cases in `test-runner.ts`
+4. Update this README with template details
+5. Test against existing mock data
+
+## Results Storage
+
+Test results are automatically saved to `results/` directory as JSON files:
+
+```json
+{
+  "templateId": "summarizer-v1.0",
+  "testId": "summarizer_1234567890",
+  "timestamp": "2024-01-01T00:00:00Z",
+  "inputs": { ... },
+  "output": "...",
+  "metrics": {
+    "completeness": 0.95,
+    "accuracy": 0.8,
+    "consistency": 0.9,
+    "responseTime": 1500
+  }
+}
+```
+
+This enables tracking template performance over time and comparing results across different versions.

--- a/prompt_tests/integration-example.ts
+++ b/prompt_tests/integration-example.ts
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+
+import { createDocumentationService } from '../src/documentation-service';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Integration example demonstrating the summarizer → doc-writer chain
+ * This shows how the two agents work together to process code changes
+ */
+
+async function demonstrateChaining() {
+  console.log('🔗 Demonstrating Agent Chaining: Summarizer → Doc Writer\n');
+  
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('❌ OPENAI_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  const docService = createDocumentationService(apiKey);
+
+  // Example: Real code changes from git.ts
+  const codeChanges = {
+    filename: 'src/git.ts',
+    filePurpose: 'Git integration module that handles repository operations and diff generation',
+    diffContent: readFileSync(join(__dirname, 'mock_inputs/git-diff-sample.txt'), 'utf-8'),
+    projectDir: process.cwd(),
+    docType: 'readme' as const,
+    targetAudience: 'developers' as const
+  };
+
+  console.log('📁 Input Code Changes:');
+  console.log(`- File: ${codeChanges.filename}`);
+  console.log(`- Purpose: ${codeChanges.filePurpose}`);
+  console.log(`- Diff Length: ${codeChanges.diffContent.length} characters`);
+  console.log(`- Doc Type: ${codeChanges.docType}`);
+  console.log(`- Target Audience: ${codeChanges.targetAudience}\n`);
+
+  try {
+    // Step 1: The service will automatically chain the agents
+    console.log('⚙️  Processing through agent chain...\n');
+    
+    const result = await docService.updateDocumentation(codeChanges);
+
+    if (result.success) {
+      console.log('✅ Agent chaining completed successfully!\n');
+      
+      // Show summarizer output
+      console.log('📋 STEP 1: Summarizer Agent Results:');
+      console.log('─'.repeat(50));
+      console.log(`Change Type: ${result.summary.change_type}`);
+      console.log(`Key Changes: ${result.summary.key_changes?.join(', ')}`);
+      console.log(`Impact Areas: ${result.summary.impact_areas?.join(', ')}`);
+      console.log(`New Dependencies: ${result.summary.new_dependencies?.join(', ') || 'None'}`);
+      console.log(`Breaking Changes: ${result.summary.breaking_changes?.join(', ') || 'None'}`);
+      
+      if (result.summary.documentation_recommendations) {
+        console.log('\n📝 Documentation Recommendations:');
+        Object.entries(result.summary.documentation_recommendations).forEach(([key, value]) => {
+          if (value) console.log(`  ${key}: ${value}`);
+        });
+      }
+      
+      // Show doc writer output
+      console.log('\n\n📝 STEP 2: Doc Writer Agent Results:');
+      console.log('─'.repeat(50));
+      console.log(`Updated Content Length: ${result.documentation.updatedContent?.length || 0} characters`);
+      console.log(`Changes Made: ${result.documentation.changeSummary?.length || 0} items`);
+      console.log(`Sections Added: ${result.documentation.sectionsAdded?.join(', ') || 'None'}`);
+      console.log(`Sections Removed: ${result.documentation.sectionsRemoved?.join(', ') || 'None'}`);
+      console.log(`Breaking Changes Detected: ${result.documentation.breakingChanges ? 'Yes' : 'No'}`);
+      
+      if (result.documentation.changeSummary?.length > 0) {
+        console.log('\n📋 Change Summary:');
+        result.documentation.changeSummary.forEach((change, index) => {
+          console.log(`  ${index + 1}. ${change}`);
+        });
+      }
+      
+      // Show a sample of the updated content
+      if (result.documentation.updatedContent) {
+        console.log('\n📄 Sample Updated Content (first 300 chars):');
+        console.log('─'.repeat(50));
+        console.log(result.documentation.updatedContent.substring(0, 300) + '...');
+      }
+      
+    } else {
+      console.log('❌ Agent chaining failed:', result.error);
+    }
+    
+  } catch (error) {
+    console.error('❌ Integration test failed:', error);
+  }
+}
+
+/**
+ * A/B test different prompt templates to show the difference
+ */
+async function demonstrateABTesting() {
+  console.log('\n\n🧪 A/B Testing Different Prompt Templates\n');
+  
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('❌ OPENAI_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  const docService = createDocumentationService(apiKey);
+
+  const testInput = {
+    filename: 'src/agents/agent.ts',
+    filePurpose: 'Core agent class that provides AI chat capabilities with tool calling support',
+    diffContent: readFileSync(join(__dirname, 'mock_inputs/agent-diff-sample.txt'), 'utf-8'),
+    projectDir: process.cwd(),
+    docType: 'readme' as const,
+    targetAudience: 'developers' as const
+  };
+
+  const templatePairs = [
+    {
+      name: 'Detailed Analysis (v1.0)',
+      summarizerTemplate: 'summarizer-v1.0',
+      docWriterTemplate: 'doc-writer-v1.0'
+    },
+    {
+      name: 'Concise Analysis (v1.1)',
+      summarizerTemplate: 'summarizer-v1.1',
+      docWriterTemplate: 'doc-writer-v1.1'
+    }
+  ];
+
+  console.log('📊 Comparing template performance...\n');
+
+  const results = await docService.testTemplates(testInput, templatePairs);
+
+  results.forEach((result, index) => {
+    console.log(`\n📋 Test ${index + 1}: ${result.name}`);
+    console.log('─'.repeat(40));
+    
+    if (result.result.success) {
+      console.log('✅ Status: Success');
+      console.log(`📊 Summary Quality: ${result.result.summary.key_changes?.length || 0} key changes identified`);
+      console.log(`📝 Doc Updates: ${result.result.documentation.changeSummary?.length || 0} changes`);
+      
+      if (result.metrics.summarizer.completeness) {
+        console.log(`🎯 Summarizer Completeness: ${(result.metrics.summarizer.completeness * 100).toFixed(1)}%`);
+      }
+      if (result.metrics.summarizer.responseTime) {
+        console.log(`⏱️  Summarizer Response Time: ${result.metrics.summarizer.responseTime}ms`);
+      }
+      
+    } else {
+      console.log('❌ Status: Failed');
+      console.log(`Error: ${result.result.error}`);
+    }
+  });
+
+  // Show comparison
+  console.log('\n📈 Performance Comparison:');
+  console.log('─'.repeat(50));
+  const comparison = docService.getTemplateComparison([
+    'summarizer-v1.0', 'summarizer-v1.1',
+    'doc-writer-v1.0', 'doc-writer-v1.1'
+  ]);
+  
+  Object.entries(comparison).forEach(([templateId, data]) => {
+    console.log(`\n${templateId}:`);
+    console.log(`  Tests: ${data.testCount}`);
+    if (data.averageMetrics) {
+      console.log(`  Avg Completeness: ${(data.averageMetrics.completeness * 100).toFixed(1)}%`);
+      console.log(`  Avg Response Time: ${Math.round(data.averageMetrics.responseTime)}ms`);
+    }
+  });
+}
+
+// Main execution
+async function main() {
+  await demonstrateChaining();
+  await demonstrateABTesting();
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/prompt_tests/mock_inputs/agent-diff-sample.txt
+++ b/prompt_tests/mock_inputs/agent-diff-sample.txt
@@ -1,0 +1,71 @@
+diff --git a/src/agents/agent.ts b/src/agents/agent.ts
+index 1234567..abcdefg 100644
+--- a/src/agents/agent.ts
++++ b/src/agents/agent.ts
+@@ -20,12 +20,18 @@ export class Agent {
+   // biome-ignore lint/suspicious/noExplicitAny: tools can be any type of tool
+   private readonly tools: Map<string, Tool<any>> = new Map();
++  private conversationHistory: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [];
+ 
+   constructor(config: AgentConfig) {
+     this.openai = new OpenAI({
+       apiKey: config.apiKey,
+     });
+     this.systemPrompt = config.systemPrompt;
+-    this.model = config.model ?? "gpt-4.1";
++    this.model = config.model ?? "gpt-4";
+     this.temperature = config.temperature ?? 0.7;
++    
++    // Initialize conversation with system prompt
++    this.conversationHistory = [
++      { role: "system", content: this.systemPrompt }
++    ];
+ 
+     if (config.tools) {
+       for (const tool of config.tools) {
+@@ -35,13 +41,23 @@ export class Agent {
+   }
+ 
+   async chat(
+-    message: string,
+-    conversationHistory: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [],
++    message: string
+   ): Promise<string> {
+-    const messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[] = [
+-      { role: "system", content: this.systemPrompt },
+-      ...conversationHistory,
+-      { role: "user", content: message },
+-    ];
++    // Add user message to conversation history
++    this.conversationHistory.push({ role: "user", content: message });
++    
++    const response = await this.processConversation();
++    
++    // Add assistant response to conversation history
++    this.conversationHistory.push({ role: "assistant", content: response });
++    
++    return response;
++  }
++  
++  private async processConversation(): Promise<string> {
++    const messages = [...this.conversationHistory];
++    
++    // Clear conversation history to prevent it from growing too large
++    this.conversationHistory = this.conversationHistory.slice(-10);
+ 
+     const tools = Array.from(this.tools.values()).map((tool) => ({
+       type: "function" as const,
+@@ -82,6 +98,13 @@ export class Agent {
+       }
+     }
+   }
++  
++  resetConversation(): void {
++    this.conversationHistory = [
++      { role: "system", content: this.systemPrompt }
++    ];
++  }
++  
++  getConversationLength(): number {
++    return this.conversationHistory.length;
++  }

--- a/prompt_tests/mock_inputs/git-diff-sample.txt
+++ b/prompt_tests/mock_inputs/git-diff-sample.txt
@@ -1,0 +1,53 @@
+diff --git a/src/git.ts b/src/git.ts
+index 1234567..abcdefg 100644
+--- a/src/git.ts
++++ b/src/git.ts
+@@ -1,10 +1,25 @@
+ import { simpleGit, SimpleGit } from 'simple-git';
++import { existsSync } from 'node:fs';
+ 
+ export class Git {
+   private git: SimpleGit;
++  private repoPath: string;
+ 
+-  constructor() {
+-    this.git = simpleGit();
++  constructor(repoPath: string = process.cwd()) {
++    this.repoPath = repoPath;
++    
++    if (!existsSync(repoPath)) {
++      throw new Error(`Repository path does not exist: ${repoPath}`);
++    }
++    
++    this.git = simpleGit(repoPath);
+   }
+ 
++  async compareRefs(baseRef?: string, headRef?: string): Promise<{ diff: string; warnings: string[] }> {
++    const warnings: string[] = [];
++    
++    // Check for unstaged changes
++    const status = await this.git.status();
++    if (status.modified.length > 0 || status.not_added.length > 0) {
++      warnings.push(`Warning: Unstaged changes detected (${status.modified.length} modified, ${status.not_added.length} untracked files). These are not included in diff calculation.`);
++    }
++    
++    let diff: string;
++    
++    if (!baseRef && !headRef) {
++      // Compare staged changes
++      const staged = await this.git.diff(['--cached']);
++      if (!staged.trim()) {
++        warnings.push('No staged changes found to compare.');
++        return { diff: '', warnings };
++      }
++      diff = staged;
++    } else {
++      // Compare specific refs
++      const base = baseRef || 'HEAD~1';
++      const head = headRef || 'HEAD';
++      diff = await this.git.diff([`${base}...${head}`]);
++    }
++    
++    return { diff, warnings };
++  }
+ }

--- a/prompt_tests/templates/doc-writer-agent.md
+++ b/prompt_tests/templates/doc-writer-agent.md
@@ -1,0 +1,184 @@
+# Doc Writer Agent Prompt Templates
+
+## Template Version: v1.0 (Comprehensive Writer)
+
+```
+You are a Documentation Writer Agent that creates and updates technical documentation based on code analysis summaries.
+
+Your task is to update existing documentation or create new documentation sections based on the provided code summary.
+
+## Input Context:
+- **Summary from Summarizer Agent**: {{code_summary}}
+- **Existing Documentation**: {{existing_doc}}
+- **Documentation Type**: {{doc_type}} (readme|api|changelog|contributing)
+- **Target Audience**: {{target_audience}} (developers|users|contributors)
+
+## Code Summary:
+<summary>
+{{code_summary}}
+</summary>
+
+## Current Documentation:
+<existing_doc>
+{{existing_doc}}
+</existing_doc>
+
+## Writing Guidelines:
+1. **Maintain Consistency**: Follow the existing documentation style and structure
+2. **User-Focused**: Write for the specified target audience
+3. **Actionable Content**: Include concrete examples and steps
+4. **Version Awareness**: Update version numbers and compatibility information
+5. **Link Management**: Ensure all internal and external links are valid
+
+## Documentation Types:
+
+### README Updates:
+- Update installation instructions for new dependencies
+- Add new features to the features list
+- Update usage examples
+- Modify configuration sections
+- Update CLI commands and options
+
+### API Documentation:
+- Document new endpoints/functions
+- Update parameter descriptions
+- Add example requests/responses
+- Note breaking changes clearly
+- Update authentication requirements
+
+### Changelog:
+- Categorize changes (Added/Changed/Deprecated/Removed/Fixed/Security)
+- Use semantic versioning
+- Include migration notes for breaking changes
+- Reference issue numbers where applicable
+
+## Output Format:
+Provide your updated documentation in the following format:
+
+<documentation_update>
+<doc_type>{{doc_type}}</doc_type>
+<updated_content>
+[Complete updated documentation content here]
+</updated_content>
+<change_summary>
+- Updated section X with new feature Y
+- Added installation instructions for dependency Z
+- Modified usage examples to reflect API changes
+</change_summary>
+</documentation_update>
+
+## Quality Checklist:
+- [ ] Spelling and grammar checked
+- [ ] Code examples are syntactically correct
+- [ ] Links are valid and accessible
+- [ ] Version numbers are current
+- [ ] Breaking changes are clearly marked
+- [ ] Examples are relevant and helpful
+```
+
+## Template Version: v1.1 (Focused Writer)
+
+```
+You are a Documentation Writer Agent. Update documentation based on code analysis.
+
+## Input:
+- **Code Summary**: {{code_summary}}
+- **Current Doc**: {{existing_doc}}
+- **Doc Type**: {{doc_type}}
+
+## Instructions:
+1. Analyze the code summary for documentation impact
+2. Update the existing documentation sections
+3. Maintain existing style and structure
+4. Focus on user-actionable information
+
+## Output:
+```markdown
+# Updated Documentation
+
+[Updated content here]
+
+## Changes Made:
+- Change 1
+- Change 2
+```
+
+Keep updates focused and maintain consistency with existing documentation.
+```
+
+## Template Version: v1.2 (Context-Aware Writer)
+
+```
+You are an Advanced Documentation Writer Agent with deep understanding of technical writing patterns.
+
+## Context:
+- **Project Type**: {{project_type}}
+- **Code Summary**: {{code_summary}}
+- **Existing Documentation**: {{existing_doc}}
+- **Documentation Type**: {{doc_type}}
+- **Target Audience**: {{target_audience}}
+- **Project Maturity**: {{project_maturity}} (alpha|beta|stable)
+
+## Advanced Writing Instructions:
+
+### Content Strategy:
+1. **Progressive Disclosure**: Layer information from basic to advanced
+2. **Contextual Examples**: Provide examples relevant to the change
+3. **Migration Paths**: For breaking changes, provide clear migration steps
+4. **Cross-References**: Link related concepts and sections
+5. **Future-Proofing**: Consider how changes might evolve
+
+### Audience Adaptation:
+- **Developers**: Focus on API details, code examples, integration patterns
+- **Users**: Focus on features, benefits, usage scenarios
+- **Contributors**: Focus on architecture, patterns, contribution guidelines
+
+### Quality Patterns:
+- **Consistency**: Maintain terminology and style throughout
+- **Completeness**: Ensure all aspects of the change are covered
+- **Clarity**: Use clear, unambiguous language
+- **Conciseness**: Be thorough but not verbose
+
+## Output Structure:
+```markdown
+# Documentation Update
+
+## Updated Sections:
+### [Section Name]
+[Updated content with clear change indicators]
+
+## New Sections:
+### [New Section Name]
+[New content with rationale for inclusion]
+
+## Deprecated Sections:
+### [Deprecated Section Name]
+[Deprecation notice and migration guidance]
+
+## Metadata:
+- Documentation Type: {{doc_type}}
+- Change Impact: High/Medium/Low
+- Review Required: Yes/No
+- Breaking Changes: Yes/No
+
+## Change Summary:
+- [Specific change 1 with rationale]
+- [Specific change 2 with rationale]
+```
+
+Focus on creating documentation that serves as a comprehensive reference and learning resource.
+```
+
+## Template Testing Framework
+
+### A/B Testing Structure:
+- **Template A**: Detailed, comprehensive approach
+- **Template B**: Concise, focused approach  
+- **Template C**: Context-aware, adaptive approach
+
+### Metrics to Track:
+- Documentation completeness
+- User comprehension
+- Maintenance overhead
+- Update accuracy
+- Style consistency

--- a/prompt_tests/templates/summarizer-agent.md
+++ b/prompt_tests/templates/summarizer-agent.md
@@ -1,0 +1,156 @@
+# Summarizer Agent Prompt Templates
+
+## Template Version: v1.0 (Detailed Analysis)
+
+```
+You are a Code Summarizer Agent that analyzes code changes and extracts key information for documentation updates.
+
+Your task is to analyze the provided code diff and generate a structured summary that will be used by the Doc Writer Agent.
+
+## Input Context:
+- **Filename**: {{filename}}
+- **File Purpose**: {{file_purpose}}
+- **Diff Content**: {{diff_content}}
+
+## Code Diff to Analyze:
+<diff>
+{{diff_content}}
+</diff>
+
+## File Context:
+<file_info>
+Filename: {{filename}}
+Purpose: {{file_purpose}}
+</file_info>
+
+## Analysis Instructions:
+1. **Identify Change Type**: Determine if this is a new feature, bug fix, refactoring, or enhancement
+2. **Extract Key Changes**: List the most important functional changes
+3. **Identify Impact**: Determine what documentation sections might need updates
+4. **Note Dependencies**: Identify any new dependencies or breaking changes
+5. **Suggest Documentation Updates**: Recommend specific sections to update
+
+## Output Format:
+Provide your analysis in the following structured format:
+
+<summary>
+{
+  "change_type": "new_feature|bug_fix|refactoring|enhancement|breaking_change",
+  "filename": "{{filename}}",
+  "file_purpose": "{{file_purpose}}",
+  "key_changes": [
+    "Brief description of change 1",
+    "Brief description of change 2"
+  ],
+  "impact_areas": [
+    "installation",
+    "usage",
+    "api_reference",
+    "configuration",
+    "dependencies"
+  ],
+  "new_dependencies": [
+    "dependency1",
+    "dependency2"
+  ],
+  "breaking_changes": [
+    "Breaking change description"
+  ],
+  "documentation_recommendations": {
+    "readme": "Specific suggestions for README updates",
+    "api_docs": "Specific suggestions for API documentation",
+    "changelog": "Specific suggestions for changelog"
+  }
+}
+</summary>
+
+Focus on extracting actionable information that will help the Doc Writer Agent create accurate and comprehensive documentation updates.
+```
+
+## Template Version: v1.1 (Concise Analysis)
+
+```
+You are a Code Summarizer Agent. Analyze the code diff and provide a concise summary for documentation updates.
+
+## Input:
+- **File**: {{filename}}
+- **Purpose**: {{file_purpose}}
+- **Diff**: {{diff_content}}
+
+## Analysis:
+Extract:
+1. Change type (feature/fix/refactor/breaking)
+2. Key functional changes (max 3)
+3. Documentation impact areas
+4. New dependencies or breaking changes
+
+## Output (JSON):
+```json
+{
+  "change_type": "...",
+  "filename": "{{filename}}",
+  "key_changes": ["...", "..."],
+  "impact_areas": ["readme", "api", "usage"],
+  "new_dependencies": [],
+  "breaking_changes": [],
+  "doc_priority": "high|medium|low"
+}
+```
+
+Keep analysis focused and actionable.
+```
+
+## Template Version: v1.2 (Context-Aware Analysis)
+
+```
+You are a Code Summarizer Agent with deep understanding of software documentation patterns.
+
+## Context:
+- **Filename**: {{filename}}
+- **File Purpose**: {{file_purpose}}
+- **Existing Documentation Context**: {{existing_doc_context}}
+
+## Code Changes:
+<diff>
+{{diff_content}}
+</diff>
+
+## Analysis Framework:
+1. **Change Classification**: Categorize the change and its scope
+2. **Documentation Impact**: Map changes to documentation sections
+3. **User Impact**: Identify how this affects end users
+4. **Integration Points**: Note how this connects to existing features
+
+## Output Structure:
+```json
+{
+  "analysis": {
+    "change_type": "...",
+    "scope": "file|module|system",
+    "user_facing": true/false,
+    "backward_compatible": true/false
+  },
+  "key_changes": [
+    {
+      "description": "...",
+      "technical_details": "...",
+      "user_impact": "..."
+    }
+  ],
+  "documentation_updates": {
+    "readme": {
+      "sections": ["installation", "usage"],
+      "priority": "high",
+      "changes": "..."
+    },
+    "api_docs": {
+      "endpoints": ["..."],
+      "parameters": ["..."],
+      "examples": true
+    }
+  }
+}
+```
+
+Focus on providing rich context that enables sophisticated documentation updates.
+```

--- a/prompt_tests/test-runner.ts
+++ b/prompt_tests/test-runner.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+import { createDocumentationService } from '../src/documentation-service';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Mock inputs for testing
+const mockInputs = {
+  gitChanges: {
+    filename: 'src/git.ts',
+    filePurpose: 'Git integration module that handles repository operations and diff generation',
+    diffContent: readFileSync(join(__dirname, 'mock_inputs/git-diff-sample.txt'), 'utf-8'),
+    projectDir: process.cwd()
+  },
+  agentChanges: {
+    filename: 'src/agents/agent.ts',
+    filePurpose: 'Core agent class that provides AI chat capabilities with tool calling support',
+    diffContent: readFileSync(join(__dirname, 'mock_inputs/agent-diff-sample.txt'), 'utf-8'),
+    projectDir: process.cwd()
+  }
+};
+
+async function testPromptTemplates() {
+  console.log('🧪 Starting Prompt Template Tests\n');
+  
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('❌ OPENAI_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  const docService = createDocumentationService(apiKey);
+
+  // Test configurations
+  const testConfigs = [
+    {
+      name: 'Detailed Analysis (v1.0)',
+      summarizerTemplate: 'summarizer-v1.0',
+      docWriterTemplate: 'doc-writer-v1.0'
+    },
+    {
+      name: 'Concise Analysis (v1.1)',
+      summarizerTemplate: 'summarizer-v1.1',
+      docWriterTemplate: 'doc-writer-v1.1'
+    }
+  ];
+
+  // Test with Git changes
+  console.log('📁 Testing with Git module changes...\n');
+  
+  const gitResults = await docService.testTemplates(mockInputs.gitChanges, testConfigs);
+  
+  for (const result of gitResults) {
+    console.log(`\n📊 Results for ${result.name}:`);
+    console.log(`Success: ${result.result.success}`);
+    
+    if (result.result.success) {
+      console.log('Summary:', JSON.stringify(result.result.summary, null, 2));
+      console.log('Documentation Changes:', result.result.documentation?.changeSummary || 'No changes detected');
+      console.log('Metrics:', JSON.stringify(result.metrics, null, 2));
+    } else {
+      console.log('Error:', result.result.error);
+    }
+    
+    console.log('-'.repeat(50));
+  }
+
+  // Test with Agent changes
+  console.log('\n🤖 Testing with Agent module changes...\n');
+  
+  const agentResults = await docService.testTemplates(mockInputs.agentChanges, testConfigs);
+  
+  for (const result of agentResults) {
+    console.log(`\n📊 Results for ${result.name}:`);
+    console.log(`Success: ${result.result.success}`);
+    
+    if (result.result.success) {
+      console.log('Summary:', JSON.stringify(result.result.summary, null, 2));
+      console.log('Documentation Changes:', result.result.documentation?.changeSummary || 'No changes detected');
+      console.log('Metrics:', JSON.stringify(result.metrics, null, 2));
+    } else {
+      console.log('Error:', result.result.error);
+    }
+    
+    console.log('-'.repeat(50));
+  }
+
+  // Get template comparison
+  console.log('\n📈 Template Performance Comparison:\n');
+  
+  const comparison = docService.getTemplateComparison([
+    'summarizer-v1.0', 'summarizer-v1.1',
+    'doc-writer-v1.0', 'doc-writer-v1.1'
+  ]);
+  
+  console.log(JSON.stringify(comparison, null, 2));
+}
+
+async function testSinglePrompt() {
+  console.log('🔍 Testing Single Prompt Template\n');
+  
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('❌ OPENAI_API_KEY environment variable is required');
+    process.exit(1);
+  }
+
+  const docService = createDocumentationService(apiKey);
+
+  try {
+    const result = await docService.updateDocumentation({
+      ...mockInputs.gitChanges,
+      docType: 'readme',
+      targetAudience: 'developers'
+    });
+
+    console.log('✅ Single prompt test results:');
+    console.log('Success:', result.success);
+    
+    if (result.success) {
+      console.log('\n📋 Summary:');
+      console.log(JSON.stringify(result.summary, null, 2));
+      
+      console.log('\n📝 Documentation Update:');
+      console.log('Updated Content Length:', result.documentation?.updatedContent?.length || 0);
+      console.log('Changes:', result.documentation?.changeSummary || []);
+      console.log('Sections Added:', result.documentation?.sectionsAdded || []);
+      console.log('Breaking Changes:', result.documentation?.breakingChanges || false);
+    } else {
+      console.log('❌ Error:', result.error);
+    }
+    
+  } catch (error) {
+    console.error('❌ Test failed:', error);
+  }
+}
+
+// Main execution
+async function main() {
+  const testType = process.argv[2];
+  
+  if (testType === 'single') {
+    await testSinglePrompt();
+  } else if (testType === 'compare') {
+    await testPromptTemplates();
+  } else {
+    console.log('Usage: npm run test-prompts [single|compare]');
+    console.log('  single  - Test a single prompt template');
+    console.log('  compare - Compare multiple prompt templates');
+  }
+}
+
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/src/agents/doc-writer-agent.ts
+++ b/src/agents/doc-writer-agent.ts
@@ -1,0 +1,221 @@
+import { promptManager } from "../prompt-manager";
+import { lsTool, readTool, treeTool, writeTool } from "../tools";
+import { Agent, type AgentConfig } from "./agent";
+import type { CodeSummary } from "./summarizer-agent";
+
+export interface DocWriterInput {
+	codeSummary: CodeSummary;
+	existingDoc: string;
+	docType: "readme" | "api" | "changelog" | "contributing";
+	targetAudience?: "developers" | "users" | "contributors";
+	projectType?: string;
+}
+
+export interface DocWriterOutput {
+	updatedContent: string;
+	changeSummary: string[];
+	sectionsAdded: string[];
+	sectionsRemoved: string[];
+	breakingChanges: boolean;
+}
+
+export class DocWriterAgent extends Agent {
+	private templateId: string;
+
+	constructor(config: AgentConfig & { templateId?: string }) {
+		super({
+			...config,
+			tools: [readTool, writeTool, treeTool, lsTool],
+		});
+		this.templateId = config.templateId || "doc-writer-v1.0";
+	}
+
+	async updateDocumentation(input: DocWriterInput): Promise<DocWriterOutput> {
+		const startTime = Date.now();
+
+		try {
+			// Render the prompt using the template
+			const prompt = promptManager.renderPrompt(this.templateId, {
+				code_summary: JSON.stringify(input.codeSummary, null, 2),
+				existing_doc: input.existingDoc,
+				doc_type: input.docType,
+				target_audience: input.targetAudience || "developers",
+				project_type: input.projectType || "library",
+			});
+
+			const response = await this.chat(prompt);
+
+			// Parse the response to extract structured information
+			const output = this.parseDocWriterResponse(response, input);
+
+			// Save test result
+			promptManager.saveTestResult({
+				templateId: this.templateId,
+				testId: `doc_writer_${Date.now()}`,
+				timestamp: new Date().toISOString(),
+				inputs: input,
+				output: response,
+				metrics: {
+					completeness: this.calculateCompleteness(output),
+					accuracy: 0.85, // Would need human evaluation
+					consistency: 0.9, // Would need comparison with existing docs
+					responseTime: Date.now() - startTime,
+				},
+			});
+
+			return output;
+		} catch (error) {
+			console.error("Error in updateDocumentation:", error);
+			throw error;
+		}
+	}
+
+	private parseDocWriterResponse(
+		response: string,
+		input: DocWriterInput,
+	): DocWriterOutput {
+		// Try to extract structured information from the response
+		const updatedContent = this.extractUpdatedContent(response);
+		const changeSummary = this.extractChangeSummary(response);
+
+		return {
+			updatedContent,
+			changeSummary,
+			sectionsAdded: this.detectSectionsAdded(
+				input.existingDoc,
+				updatedContent,
+			),
+			sectionsRemoved: this.detectSectionsRemoved(
+				input.existingDoc,
+				updatedContent,
+			),
+			breakingChanges: input.codeSummary.breaking_changes.length > 0,
+		};
+	}
+
+	private extractUpdatedContent(response: string): string {
+		// Look for markdown content in the response
+		const markdownMatch = response.match(/```markdown\n([\s\S]*?)\n```/);
+		if (markdownMatch) {
+			return markdownMatch[1];
+		}
+
+		// If no markdown block, look for content after headers
+		const contentMatch = response.match(
+			/(?:# Updated Documentation|## Updated Content|Updated Documentation:)\n\n([\s\S]*?)(?:\n## |$)/,
+		);
+		if (contentMatch) {
+			return contentMatch[1].trim();
+		}
+
+		// Fall back to the entire response
+		return response;
+	}
+
+	private extractChangeSummary(response: string): string[] {
+		const changes: string[] = [];
+
+		// Look for change summary section
+		const summaryMatch = response.match(
+			/(?:## Changes Made|Change Summary|## Change Summary):\n([\s\S]*?)(?:\n## |$)/,
+		);
+		if (summaryMatch) {
+			const summaryText = summaryMatch[1];
+			const changeLines = summaryText
+				.split("\n")
+				.map((line) => line.trim())
+				.filter(
+					(line) =>
+						line.startsWith("-") ||
+						line.startsWith("*") ||
+						line.startsWith("•"),
+				)
+				.map((line) => line.replace(/^[-*•]\s*/, ""));
+
+			changes.push(...changeLines);
+		}
+
+		// If no explicit summary, try to infer from content
+		if (changes.length === 0) {
+			if (
+				response.includes("Added") ||
+				response.includes("Updated") ||
+				response.includes("Modified")
+			) {
+				changes.push("Documentation updated based on code changes");
+			}
+		}
+
+		return changes;
+	}
+
+	private detectSectionsAdded(oldDoc: string, newDoc: string): string[] {
+		const oldHeaders = this.extractHeaders(oldDoc);
+		const newHeaders = this.extractHeaders(newDoc);
+
+		return newHeaders.filter((header) => !oldHeaders.includes(header));
+	}
+
+	private detectSectionsRemoved(oldDoc: string, newDoc: string): string[] {
+		const oldHeaders = this.extractHeaders(oldDoc);
+		const newHeaders = this.extractHeaders(newDoc);
+
+		return oldHeaders.filter((header) => !newHeaders.includes(header));
+	}
+
+	private extractHeaders(content: string): string[] {
+		const headerRegex = /^(#{1,6})\s+(.+)$/gm;
+		const headers: string[] = [];
+		let match: RegExpExecArray | null;
+
+		while ((match = headerRegex.exec(content)) !== null) {
+			headers.push(match[2].trim());
+		}
+
+		return headers;
+	}
+
+	private calculateCompleteness(output: DocWriterOutput): number {
+		let score = 0;
+
+		// Check if updated content exists and is substantial
+		if (output.updatedContent && output.updatedContent.length > 100)
+			score += 0.4;
+
+		// Check if change summary exists
+		if (output.changeSummary && output.changeSummary.length > 0) score += 0.3;
+
+		// Check if sections were properly detected
+		if (
+			output.sectionsAdded !== undefined &&
+			output.sectionsRemoved !== undefined
+		)
+			score += 0.2;
+
+		// Check if breaking changes were handled
+		if (output.breakingChanges !== undefined) score += 0.1;
+
+		return score;
+	}
+
+	setTemplate(templateId: string): void {
+		this.templateId = templateId;
+	}
+
+	getTemplate(): string {
+		return this.templateId;
+	}
+}
+
+export function createDocWriterAgent(
+	apiKey: string,
+	templateId?: string,
+): DocWriterAgent {
+	return new DocWriterAgent({
+		apiKey,
+		model: "gpt-4",
+		systemPrompt: "", // Will be set by template
+		temperature: 0.4, // Slightly higher for more creative writing
+		templateId,
+	});
+}

--- a/src/agents/summarizer-agent.ts
+++ b/src/agents/summarizer-agent.ts
@@ -1,0 +1,139 @@
+import { promptManager } from "../prompt-manager";
+import { Agent, type AgentConfig } from "./agent";
+
+export interface CodeSummaryInput {
+	filename: string;
+	filePurpose: string;
+	diffContent: string;
+	existingDocContext?: string;
+}
+
+export interface CodeSummary {
+	change_type:
+		| "new_feature"
+		| "bug_fix"
+		| "refactoring"
+		| "enhancement"
+		| "breaking_change";
+	filename: string;
+	file_purpose: string;
+	key_changes: string[];
+	impact_areas: string[];
+	new_dependencies: string[];
+	breaking_changes: string[];
+	documentation_recommendations: {
+		readme?: string;
+		api_docs?: string;
+		changelog?: string;
+	};
+	doc_priority?: "high" | "medium" | "low";
+}
+
+export class SummarizerAgent extends Agent {
+	private templateId: string;
+
+	constructor(config: AgentConfig & { templateId?: string }) {
+		super(config);
+		this.templateId = config.templateId || "summarizer-v1.0";
+	}
+
+	async summarizeChanges(input: CodeSummaryInput): Promise<CodeSummary> {
+		const startTime = Date.now();
+
+		try {
+			// Render the prompt using the template
+			const prompt = promptManager.renderPrompt(this.templateId, {
+				filename: input.filename,
+				file_purpose: input.filePurpose,
+				diff_content: input.diffContent,
+				existing_doc_context: input.existingDocContext || "",
+			});
+
+			const response = await this.chat(prompt);
+
+			// Try to parse JSON response
+			let summary: CodeSummary;
+			try {
+				// Extract JSON from response if it's wrapped in markdown or text
+				const jsonMatch = response.match(/\{[\s\S]*\}/);
+				const jsonString = jsonMatch ? jsonMatch[0] : response;
+				summary = JSON.parse(jsonString);
+			} catch (parseError) {
+				// If parsing fails, create a basic summary
+				console.warn("Failed to parse JSON response, creating basic summary");
+				summary = {
+					change_type: "enhancement",
+					filename: input.filename,
+					file_purpose: input.filePurpose,
+					key_changes: [response.substring(0, 100)],
+					impact_areas: ["readme"],
+					new_dependencies: [],
+					breaking_changes: [],
+					documentation_recommendations: {
+						readme: response,
+					},
+				};
+			}
+
+			// Save test result
+			promptManager.saveTestResult({
+				templateId: this.templateId,
+				testId: `summarizer_${Date.now()}`,
+				timestamp: new Date().toISOString(),
+				inputs: input,
+				output: response,
+				metrics: {
+					completeness: this.calculateCompleteness(summary),
+					accuracy: 0.8, // Would need human evaluation
+					consistency: 0.9, // Would need comparison with other results
+					responseTime: Date.now() - startTime,
+				},
+			});
+
+			return summary;
+		} catch (error) {
+			console.error("Error in summarizeChanges:", error);
+			throw error;
+		}
+	}
+
+	private calculateCompleteness(summary: CodeSummary): number {
+		const requiredFields = [
+			"change_type",
+			"filename",
+			"key_changes",
+			"impact_areas",
+		];
+		const presentFields = requiredFields.filter((field) => {
+			const value = summary[field as keyof CodeSummary];
+			return (
+				value !== undefined &&
+				value !== null &&
+				(Array.isArray(value) ? value.length > 0 : String(value).length > 0)
+			);
+		});
+
+		return presentFields.length / requiredFields.length;
+	}
+
+	setTemplate(templateId: string): void {
+		this.templateId = templateId;
+	}
+
+	getTemplate(): string {
+		return this.templateId;
+	}
+}
+
+export function createSummarizerAgent(
+	apiKey: string,
+	templateId?: string,
+): SummarizerAgent {
+	return new SummarizerAgent({
+		apiKey,
+		model: "gpt-4",
+		systemPrompt: "", // Will be set by template
+		temperature: 0.3, // Lower temperature for more consistent analysis
+		templateId,
+	});
+}

--- a/src/documentation-service.ts
+++ b/src/documentation-service.ts
@@ -1,0 +1,248 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	type DocWriterAgent,
+	type DocWriterInput,
+	createDocWriterAgent,
+} from "./agents/doc-writer-agent";
+import {
+	type CodeSummaryInput,
+	type SummarizerAgent,
+	createSummarizerAgent,
+} from "./agents/summarizer-agent";
+import { promptManager } from "./prompt-manager";
+
+export interface DocumentationUpdateRequest {
+	filename: string;
+	filePurpose: string;
+	diffContent: string;
+	projectDir: string;
+	docType?: "readme" | "api" | "changelog" | "contributing";
+	targetAudience?: "developers" | "users" | "contributors";
+	summarizerTemplate?: string;
+	docWriterTemplate?: string;
+}
+
+export interface DocumentationUpdateResult {
+	summary: any;
+	documentation: any;
+	success: boolean;
+	error?: string;
+}
+
+export class DocumentationService {
+	private summarizerAgent: SummarizerAgent;
+	private docWriterAgent: DocWriterAgent;
+	private apiKey: string;
+
+	constructor(apiKey: string) {
+		this.apiKey = apiKey;
+
+		// Initialize prompt manager with default templates
+		promptManager.loadDefaultTemplates();
+
+		// Create agents with default templates
+		this.summarizerAgent = createSummarizerAgent(apiKey);
+		this.docWriterAgent = createDocWriterAgent(apiKey);
+	}
+
+	async updateDocumentation(
+		request: DocumentationUpdateRequest,
+	): Promise<DocumentationUpdateResult> {
+		try {
+			// Step 1: Summarize the code changes
+			console.log("🔍 Analyzing code changes...");
+
+			// Switch templates if specified
+			if (request.summarizerTemplate) {
+				this.summarizerAgent.setTemplate(request.summarizerTemplate);
+			}
+			if (request.docWriterTemplate) {
+				this.docWriterAgent.setTemplate(request.docWriterTemplate);
+			}
+
+			const summaryInput: CodeSummaryInput = {
+				filename: request.filename,
+				filePurpose: request.filePurpose,
+				diffContent: request.diffContent,
+				existingDocContext: this.getExistingDocContext(
+					request.projectDir,
+					request.docType || "readme",
+				),
+			};
+
+			const summary = await this.summarizerAgent.summarizeChanges(summaryInput);
+			console.log("✅ Code analysis complete");
+
+			// Step 2: Update documentation based on summary
+			console.log("📝 Updating documentation...");
+
+			const existingDoc = this.getExistingDocumentation(
+				request.projectDir,
+				request.docType || "readme",
+			);
+
+			const docWriterInput: DocWriterInput = {
+				codeSummary: summary,
+				existingDoc,
+				docType: request.docType || "readme",
+				targetAudience: request.targetAudience || "developers",
+				projectType: this.detectProjectType(request.projectDir),
+			};
+
+			const documentation =
+				await this.docWriterAgent.updateDocumentation(docWriterInput);
+			console.log("✅ Documentation update complete");
+
+			return {
+				summary,
+				documentation,
+				success: true,
+			};
+		} catch (error) {
+			console.error("❌ Documentation update failed:", error);
+			return {
+				summary: null,
+				documentation: null,
+				success: false,
+				error: error instanceof Error ? error.message : "Unknown error",
+			};
+		}
+	}
+
+	private getExistingDocumentation(
+		projectDir: string,
+		docType: string,
+	): string {
+		const docFiles = {
+			readme: "README.md",
+			api: "API.md",
+			changelog: "CHANGELOG.md",
+			contributing: "CONTRIBUTING.md",
+		};
+
+		const filename = docFiles[docType as keyof typeof docFiles] || "README.md";
+		const filepath = join(projectDir, filename);
+
+		if (existsSync(filepath)) {
+			return readFileSync(filepath, "utf-8");
+		}
+
+		return `# ${this.getProjectName(projectDir)}
+
+This documentation file will be created based on your code changes.
+`;
+	}
+
+	private getExistingDocContext(projectDir: string, docType: string): string {
+		const existingDoc = this.getExistingDocumentation(projectDir, docType);
+
+		// Extract key sections for context
+		const headers = existingDoc.match(/^#{1,6}\s+(.+)$/gm) || [];
+		const sections = headers.map((h) => h.replace(/^#+\s+/, "")).join(", ");
+
+		return `Existing sections: ${sections}`;
+	}
+
+	private detectProjectType(projectDir: string): string {
+		const packageJsonPath = join(projectDir, "package.json");
+		const pyprojectPath = join(projectDir, "pyproject.toml");
+		const cargoPath = join(projectDir, "Cargo.toml");
+
+		if (existsSync(packageJsonPath)) {
+			try {
+				const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+				if (packageJson.type === "module") return "ES Module";
+				if (packageJson.bin) return "CLI Tool";
+				if (packageJson.scripts?.start) return "Application";
+				return "Node.js Library";
+			} catch {
+				return "Node.js Project";
+			}
+		}
+
+		if (existsSync(pyprojectPath)) return "Python Project";
+		if (existsSync(cargoPath)) return "Rust Project";
+
+		return "Software Project";
+	}
+
+	private getProjectName(projectDir: string): string {
+		const packageJsonPath = join(projectDir, "package.json");
+
+		if (existsSync(packageJsonPath)) {
+			try {
+				const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+				return packageJson.name || "Project";
+			} catch {
+				// Fall through to directory name
+			}
+		}
+
+		return projectDir.split("/").pop() || "Project";
+	}
+
+	/**
+	 * A/B test different prompt templates
+	 */
+	async testTemplates(
+		request: DocumentationUpdateRequest,
+		templatePairs: Array<{
+			summarizerTemplate: string;
+			docWriterTemplate: string;
+			name: string;
+		}>,
+	): Promise<
+		Array<{
+			name: string;
+			result: DocumentationUpdateResult;
+			metrics: any;
+		}>
+	> {
+		const results = [];
+
+		for (const templatePair of templatePairs) {
+			console.log(`\n🧪 Testing template pair: ${templatePair.name}`);
+
+			const testRequest = {
+				...request,
+				summarizerTemplate: templatePair.summarizerTemplate,
+				docWriterTemplate: templatePair.docWriterTemplate,
+			};
+
+			const result = await this.updateDocumentation(testRequest);
+
+			// Get metrics from prompt manager
+			const summarizerResults = promptManager.getTestResults(
+				templatePair.summarizerTemplate,
+			);
+			const docWriterResults = promptManager.getTestResults(
+				templatePair.docWriterTemplate,
+			);
+
+			results.push({
+				name: templatePair.name,
+				result,
+				metrics: {
+					summarizer: summarizerResults[0]?.metrics || {},
+					docWriter: docWriterResults[0]?.metrics || {},
+				},
+			});
+		}
+
+		return results;
+	}
+
+	/**
+	 * Get performance comparison between templates
+	 */
+	getTemplateComparison(templateIds: string[]): Record<string, any> {
+		return promptManager.compareTemplates(templateIds);
+	}
+}
+
+export function createDocumentationService(
+	apiKey: string,
+): DocumentationService {
+	return new DocumentationService(apiKey);
+}

--- a/src/prompt-manager.ts
+++ b/src/prompt-manager.ts
@@ -1,0 +1,357 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+export interface PromptTemplate {
+	id: string;
+	version: string;
+	name: string;
+	description: string;
+	template: string;
+	variables: string[];
+	category: "summarizer" | "doc-writer";
+}
+
+export interface PromptTestResult {
+	templateId: string;
+	testId: string;
+	timestamp: string;
+	inputs: Record<string, any>;
+	output: string;
+	metrics: {
+		completeness: number;
+		accuracy: number;
+		consistency: number;
+		responseTime: number;
+	};
+	notes?: string;
+}
+
+export class PromptManager {
+	private readonly promptsDir: string;
+	private readonly testsDir: string;
+	private readonly templates: Map<string, PromptTemplate> = new Map();
+
+	constructor(baseDir = "./prompt_tests") {
+		this.promptsDir = join(baseDir, "templates");
+		this.testsDir = join(baseDir, "results");
+
+		// Ensure directories exist
+		if (!existsSync(this.promptsDir)) {
+			mkdirSync(this.promptsDir, { recursive: true });
+		}
+		if (!existsSync(this.testsDir)) {
+			mkdirSync(this.testsDir, { recursive: true });
+		}
+	}
+
+	/**
+	 * Register a prompt template
+	 */
+	registerTemplate(template: PromptTemplate): void {
+		this.templates.set(template.id, template);
+	}
+
+	/**
+	 * Get a prompt template by ID
+	 */
+	getTemplate(id: string): PromptTemplate | undefined {
+		return this.templates.get(id);
+	}
+
+	/**
+	 * Get all templates for a category
+	 */
+	getTemplatesByCategory(
+		category: "summarizer" | "doc-writer",
+	): PromptTemplate[] {
+		return Array.from(this.templates.values()).filter(
+			(t) => t.category === category,
+		);
+	}
+
+	/**
+	 * Render a prompt template with variables
+	 */
+	renderPrompt(templateId: string, variables: Record<string, any>): string {
+		const template = this.getTemplate(templateId);
+		if (!template) {
+			throw new Error(`Template ${templateId} not found`);
+		}
+
+		let rendered = template.template;
+
+		// Replace variables in the template
+		for (const [key, value] of Object.entries(variables)) {
+			const regex = new RegExp(`{{${key}}}`, "g");
+			rendered = rendered.replace(regex, String(value));
+		}
+
+		// Check for unreplaced variables
+		const unreplaced = rendered.match(/{{([^}]+)}}/g);
+		if (unreplaced) {
+			console.warn(
+				`Warning: Unreplaced variables found: ${unreplaced.join(", ")}`,
+			);
+		}
+
+		return rendered;
+	}
+
+	/**
+	 * Save test result
+	 */
+	saveTestResult(result: PromptTestResult): void {
+		const filename = `${result.testId}_${result.templateId}_${Date.now()}.json`;
+		const filepath = join(this.testsDir, filename);
+		writeFileSync(filepath, JSON.stringify(result, null, 2));
+	}
+
+	/**
+	 * Load test results for a template
+	 */
+	getTestResults(templateId: string): PromptTestResult[] {
+		const results: PromptTestResult[] = [];
+
+		try {
+			const files = require("node:fs").readdirSync(this.testsDir);
+			for (const file of files) {
+				if (file.includes(templateId) && file.endsWith(".json")) {
+					const filepath = join(this.testsDir, file);
+					const content = readFileSync(filepath, "utf-8");
+					results.push(JSON.parse(content));
+				}
+			}
+		} catch (error) {
+			console.warn(`Could not load test results: ${error}`);
+		}
+
+		return results.sort(
+			(a, b) =>
+				new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+		);
+	}
+
+	/**
+	 * Compare template performance
+	 */
+	compareTemplates(templateIds: string[]): Record<string, any> {
+		const comparison: Record<string, any> = {};
+
+		for (const templateId of templateIds) {
+			const results = this.getTestResults(templateId);
+			if (results.length === 0) continue;
+
+			const metrics = results.reduce(
+				(acc, result) => {
+					acc.completeness += result.metrics.completeness;
+					acc.accuracy += result.metrics.accuracy;
+					acc.consistency += result.metrics.consistency;
+					acc.responseTime += result.metrics.responseTime;
+					return acc;
+				},
+				{ completeness: 0, accuracy: 0, consistency: 0, responseTime: 0 },
+			);
+
+			comparison[templateId] = {
+				testCount: results.length,
+				averageMetrics: {
+					completeness: metrics.completeness / results.length,
+					accuracy: metrics.accuracy / results.length,
+					consistency: metrics.consistency / results.length,
+					responseTime: metrics.responseTime / results.length,
+				},
+				template: this.getTemplate(templateId),
+			};
+		}
+
+		return comparison;
+	}
+
+	/**
+	 * Export prompt templates to markdown
+	 */
+	exportTemplate(templateId: string): string {
+		const template = this.getTemplate(templateId);
+		if (!template) {
+			throw new Error(`Template ${templateId} not found`);
+		}
+
+		return `# ${template.name} (${template.version})
+
+## Description
+${template.description}
+
+## Variables
+${template.variables.map((v) => `- \`{{${v}}}\``).join("\n")}
+
+## Template
+\`\`\`
+${template.template}
+\`\`\`
+
+## Category
+${template.category}
+`;
+	}
+
+	/**
+	 * Load templates from predefined templates
+	 */
+	loadDefaultTemplates(): void {
+		// Summarizer templates
+		this.registerTemplate({
+			id: "summarizer-v1.0",
+			version: "v1.0",
+			name: "Detailed Analysis Summarizer",
+			description: "Comprehensive code analysis with structured output",
+			category: "summarizer",
+			variables: ["filename", "file_purpose", "diff_content"],
+			template: `You are a Code Summarizer Agent that analyzes code changes and extracts key information for documentation updates.
+
+Your task is to analyze the provided code diff and generate a structured summary that will be used by the Doc Writer Agent.
+
+## Input Context:
+- **Filename**: {{filename}}
+- **File Purpose**: {{file_purpose}}
+- **Diff Content**: {{diff_content}}
+
+## Analysis Instructions:
+1. **Identify Change Type**: Determine if this is a new feature, bug fix, refactoring, or enhancement
+2. **Extract Key Changes**: List the most important functional changes
+3. **Identify Impact**: Determine what documentation sections might need updates
+4. **Note Dependencies**: Identify any new dependencies or breaking changes
+5. **Suggest Documentation Updates**: Recommend specific sections to update
+
+## Output Format:
+Provide your analysis in the following JSON format:
+
+{
+  "change_type": "new_feature|bug_fix|refactoring|enhancement|breaking_change",
+  "filename": "{{filename}}",
+  "file_purpose": "{{file_purpose}}",
+  "key_changes": [
+    "Brief description of change 1",
+    "Brief description of change 2"
+  ],
+  "impact_areas": [
+    "installation",
+    "usage",
+    "api_reference",
+    "configuration",
+    "dependencies"
+  ],
+  "new_dependencies": [],
+  "breaking_changes": [],
+  "documentation_recommendations": {
+    "readme": "Specific suggestions for README updates",
+    "api_docs": "Specific suggestions for API documentation",
+    "changelog": "Specific suggestions for changelog"
+  }
+}
+
+Focus on extracting actionable information that will help the Doc Writer Agent create accurate and comprehensive documentation updates.`,
+		});
+
+		this.registerTemplate({
+			id: "summarizer-v1.1",
+			version: "v1.1",
+			name: "Concise Analysis Summarizer",
+			description: "Quick, focused code analysis with minimal output",
+			category: "summarizer",
+			variables: ["filename", "file_purpose", "diff_content"],
+			template: `You are a Code Summarizer Agent. Analyze the code diff and provide a concise summary for documentation updates.
+
+## Input:
+- **File**: {{filename}}
+- **Purpose**: {{file_purpose}}
+- **Diff**: {{diff_content}}
+
+## Analysis:
+Extract:
+1. Change type (feature/fix/refactor/breaking)
+2. Key functional changes (max 3)
+3. Documentation impact areas
+4. New dependencies or breaking changes
+
+## Output (JSON):
+{
+  "change_type": "...",
+  "filename": "{{filename}}",
+  "key_changes": ["...", "..."],
+  "impact_areas": ["readme", "api", "usage"],
+  "new_dependencies": [],
+  "breaking_changes": [],
+  "doc_priority": "high|medium|low"
+}
+
+Keep analysis focused and actionable.`,
+		});
+
+		// Doc Writer templates
+		this.registerTemplate({
+			id: "doc-writer-v1.0",
+			version: "v1.0",
+			name: "Comprehensive Documentation Writer",
+			description: "Detailed documentation updates with quality checklist",
+			category: "doc-writer",
+			variables: [
+				"code_summary",
+				"existing_doc",
+				"doc_type",
+				"target_audience",
+			],
+			template: `You are a Documentation Writer Agent that creates and updates technical documentation based on code analysis summaries.
+
+## Input Context:
+- **Code Summary**: {{code_summary}}
+- **Existing Documentation**: {{existing_doc}}
+- **Documentation Type**: {{doc_type}}
+- **Target Audience**: {{target_audience}}
+
+## Writing Guidelines:
+1. **Maintain Consistency**: Follow the existing documentation style and structure
+2. **User-Focused**: Write for the specified target audience
+3. **Actionable Content**: Include concrete examples and steps
+4. **Version Awareness**: Update version numbers and compatibility information
+
+## Output Format:
+Provide your updated documentation in markdown format, followed by a change summary.
+
+## Change Summary:
+- List the specific changes made
+- Note any sections added or removed
+- Highlight breaking changes if any
+
+Focus on creating clear, actionable documentation that serves your target audience.`,
+		});
+
+		this.registerTemplate({
+			id: "doc-writer-v1.1",
+			version: "v1.1",
+			name: "Focused Documentation Writer",
+			description: "Quick documentation updates with minimal overhead",
+			category: "doc-writer",
+			variables: ["code_summary", "existing_doc", "doc_type"],
+			template: `You are a Documentation Writer Agent. Update documentation based on code analysis.
+
+## Input:
+- **Code Summary**: {{code_summary}}
+- **Current Doc**: {{existing_doc}}
+- **Doc Type**: {{doc_type}}
+
+## Instructions:
+1. Analyze the code summary for documentation impact
+2. Update the existing documentation sections
+3. Maintain existing style and structure
+4. Focus on user-actionable information
+
+## Output:
+Provide updated documentation in markdown format.
+
+Keep updates focused and maintain consistency with existing documentation.`,
+		});
+	}
+}
+
+// Export singleton instance
+export const promptManager = new PromptManager();


### PR DESCRIPTION
- Design **modular prompt templates**:
    - a) For summarizing code chunks (`Summarizer Agent`)
    - b) For updating markdown files (`Doc Writer Agent`)
- Include: filename, diff summary, file purpose, and existing doc context
- Test with 1–2 real files using mock inputs
- Ensure tool-calling correctly chains summarizer → doc-writer agent
- Save prompt variants and results to `prompt_tests/`

Add a simple prompt manager so you can A/B test prompts quickly

- [X] Tested by generating the updated README.md